### PR TITLE
fix: bad Omyonic link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Hi 👋 My name is George
 Backend developer. ITMO OOP mentor. 
 -----------------------------------  
 Third year ITMO University student. 
-Head backend developer at [Omyonic](omyonic.com). 
+Head backend developer at [Omyonic](https://omyonic.com). 
 Middle backend C# developer at InfoWise. 
 OOP mentor at ITMO University. 
 Lot of work needs a lot of rest, so my free time I spend writing C# libraries.  


### PR DESCRIPTION
Current link was leading to github.com/ronimizy/ronimizy/blob/master/omyonic.com, not actual site